### PR TITLE
Fix extra allocation and copy.

### DIFF
--- a/src/Alturos.Yolo.UnitTest/BasicTest.cs
+++ b/src/Alturos.Yolo.UnitTest/BasicTest.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Alturos.Yolo.UnitTest
 {
@@ -27,7 +27,7 @@ namespace Alturos.Yolo.UnitTest
             using (var yoloWrapper = new YoloWrapper(configuration))
             {
                 var items = yoloWrapper.Detect(this._imagePath);
-                Assert.IsTrue(items.Count() > 0);
+                Assert.IsTrue(items.Any());
             }
         }
 
@@ -39,7 +39,7 @@ namespace Alturos.Yolo.UnitTest
             {
                 var imageData = File.ReadAllBytes(this._imagePath);
                 var items = yoloWrapper.Detect(imageData);
-                Assert.IsTrue(items.Count() > 0);
+                Assert.IsTrue(items.Any());
             }
         }
     }

--- a/src/Alturos.Yolo/Alturos.Yolo.csproj
+++ b/src/Alturos.Yolo/Alturos.Yolo.csproj
@@ -16,6 +16,7 @@
     <Version>3.0.6-alpha</Version>
     <AssemblyVersion>3.0.6</AssemblyVersion>
     <FileVersion>3.0.6</FileVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Only for .netstandard 2.0 -->


### PR DESCRIPTION
Inside `YoloWrapper.Detect(byte[])` there's a costly allocation and copy of the image buffer. This can be prevented by pinning the provided array instead.

There was also `Marshal.SizeOf(imageData[0])` which since the supplied buffer is `byte[]` is an expensive way (has a memory read and `Marshal.SizeOf` is not cheap/free like `sizeof`) to get the constant `1`.